### PR TITLE
support timespan argument for query

### DIFF
--- a/analytics/client.py
+++ b/analytics/client.py
@@ -23,8 +23,10 @@ class AnalyticsClient(object):
             self._app_id = app_id
             self._app_key = app_key
 
-    def query(self, query):
+    def query(self, query, timespan=None):
         data = { 'query' :  query }
+        if timespan:
+            data['timespan'] = timespan
         headers = { 
             'x-api-key': self._app_key,
             'Content-Type': 'application/json',


### PR DESCRIPTION
Allow use of timespan argument in query as in `client.query(qry, timespan="P7D")` to restrict to last 7 days